### PR TITLE
feat: count using subquery for distinct=true

### DIFF
--- a/lib/ecto_paginator/ecto_paginator.ex
+++ b/lib/ecto_paginator/ecto_paginator.ex
@@ -111,6 +111,12 @@ defmodule EctoPaginator do
     |> count()
   end
 
+  defp aggregate(%{distinct: %{expr: true}} = query) do
+    query
+    |> exclude(:select)
+    |> count()
+  end
+
   defp aggregate(
          %{
            group_bys: [


### PR DESCRIPTION
Use count via subquery for `dictinct(true)` queries